### PR TITLE
Add player loaded check when trying to join island

### DIFF
--- a/src/features/IslandCodes.cpp
+++ b/src/features/IslandCodes.cpp
@@ -445,6 +445,11 @@ namespace CTRPluginFramework {
 			using enum State;
 			static State state = Init;
 
+			if (!PlayerClass::GetInstance()->IsLoaded()) {
+				OSD::NotifySysFont(Language::getInstance()->get(TextID::SAVE_PLAYER_NO), Color::Red);
+				return;
+			}
+
 			GameLoopHook::GetInstance()->Add(+[] {
 				auto& instance = GetInstance();
 				auto* language = Language::getInstance();


### PR DESCRIPTION
Adds a check to island join function to prevent crashing when no player is loaded